### PR TITLE
Few small improvements

### DIFF
--- a/src/echo.rs
+++ b/src/echo.rs
@@ -69,6 +69,16 @@ pub async fn deploy(
         .await
 }
 
+/// Checks if an echo deployment exists.
+pub async fn is_deployed(client: Client, name: &str, namespace: &str) -> Result<bool, Error> {
+    let deployment_api: Api<Deployment> = Api::namespaced(client, namespace);
+    let response = deployment_api.get(name).await;
+    if let Err(Error::Api(ErrorResponse { code: 404, .. })) = response {
+        return Ok(false);
+    }
+    response.map(|_| true)
+}
+
 /// Deletes an existing deployment.
 ///
 /// # Arguments:

--- a/src/finalizer.rs
+++ b/src/finalizer.rs
@@ -16,7 +16,7 @@ pub async fn add(client: Client, name: &str, namespace: &str) -> Result<Echo, Er
     let api: Api<Echo> = Api::namespaced(client, namespace);
     let finalizer: Value = json!({
         "metadata": {
-            "finalizers": ["echoes.example.com"]
+            "finalizers": ["echoes.example.com/finalizer"]
         }
     });
 


### PR DESCRIPTION
1. Use a fully qualified finalizer name. Because of the way the finalizer code is written (clears all finalizers before delete), this will work with existing deployed echos, which isn't super important for an example app, but kind of neat. I discovered this when getting an error using this finalizer name on a deployment, and the kube builder book recommended adding a `/finalizer` suffix. https://book.kubebuilder.io/reference/using-finalizers.html
2. Make `echo::delete` a no-op if the deployment was manually deleted. Currently it just fails. Again, example app, but gives an example for doing it.
3. Check for existence of a deployment in the reconciliation path. If the deployment was manually deleted, recreate it. This one could certainly be removed from this PR for now. In the future I'd like to follow up with a PR that updates the replica count as the CRD changes.

A few small improvements. Wanted to offer them up. Feel free to close this PR if you're 👎 . Thanks! 
