### PR TITLE
Use a full qualified finalizer name

### DIFF
--- a/src/finalizer.rs
+++ b/src/finalizer.rs
@@ -16,7 +16,7 @@ pub async fn add(client: Client, name: &str, namespace: &str) -> Result<Echo, Er
     let api: Api<Echo> = Api::namespaced(client, namespace);
     let finalizer: Value = json!({
         "metadata": {
-            "finalizers": ["echoes.example.com"]
+            "finalizers": ["echoes.example.com/finalizer"]
         }
     });
 


### PR DESCRIPTION
Continuation of https://github.com/Pscheidl/rust-kubernetes-operator-example/pull/9

Use a fully qualified finalizer name. Because of the way the finalizer code is written (clears all finalizers before delete), this will work with existing deployed echos, which isn't super important for an example app, but kind of neat. I discovered this when getting an error using this finalizer name on a deployment, and the kube builder book recommended adding a /finalizer suffix. https://book.kubebuilder.io/reference/using-finalizers.html

@Pscheidl I'm so sorry for not responding to the other PR before. I completely missed the notification. Here's just the first commit from #9 .